### PR TITLE
Fix creation of SSL binding. X509Certificate2Collection.Find was dropping provider information on the cert.

### DIFF
--- a/ConDep.Dsl/PSScripts/Iis.ps1
+++ b/ConDep.Dsl/PSScripts/Iis.ps1
@@ -154,7 +154,7 @@ function AssociateCertificateWithBinding {
 			Remove-Item -Path "IIS:\\SslBindings\$bindingIp!$port" -ErrorAction SilentlyContinue
 			
 			#netsh http add sslcert ipport=$bindingIp:$port certhash=d9744c1e37bd575b431fed64e4e52cae9faced46 appid={5C7D7048-6609-4298-A2ED-6EFB68A66FF3} certstorename=MY clientcertnegotiation=enable
-		    New-Item -Path "IIS:\\SslBindings\$bindingIp!$port" -Value $webSiteCert
+			New-Item -Path "IIS:\\SslBindings\$bindingIp!$port" -Value (Get-Item cert:\LocalMachine\MY\$($webSiteCert.Thumbprint))
 		}
 	}
 }


### PR DESCRIPTION
Adding the SSL binding was failing for me with:

> New-Item : Object reference not set to an instance of an object.
> At C:\Windows\Temp\ConDep\0ddfbeef-9723-4a42-9adc-ebf82f671b10\PSScripts\ConDep\Iis.ps1:158 char:7

Eventually I traced this to the fact that the provider properties were getting dropped by X509Certificate2Collection.Find.

Here is a command showing :

``` Powershell
Compare-Object (Get-Item Cert:\LocalMachine\My\1234567890ABCDEF8E9711CD7BEB3406B673DA1E | Get-Member) ((New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection(,(Get-ChildItem cert:\\LocalMachine\\MY))).Find("FindByThumbprint", "1234567890ABCDEF8E9711CD7BEB3406B673DA1E", $False) | Select -First 1 | Get-Member)
InputObject                                                                                    SideIndicator                                                                                
-----------                                                                                    -------------                                                                                
System.String PSChildName=1234567890ABCDEF8E9711CD7BEB3406B673DA1E                             <=                                                                                           
System.Management.Automation.PSDriveInfo PSDrive=Cert                                          <=                                                                                           
System.Boolean PSIsContainer=False                                                             <=                                                                                           
System.String PSParentPath=Microsoft.PowerShell.Security\Certificate::LocalMachine\My          <=                                                                                           
System.String PSPath=Microsoft.PowerShell.Security\Certificate::LocalMachine\My\1234567890A... <=                                                                                           
System.Management.Automation.ProviderInfo PSProvider=Microsoft.PowerShell.Security\Certificate <=
```

This was happening for me on Windows Server 2012 running ConDep 2.0.12.

The solution proposed is to just get the retrieve the cert again by thumbprint to make sure it has the necessary provider properties.
