### PR TITLE
We do not need ConDepModule on PostRemoteOps

### DIFF
--- a/ConDep.Dsl/Operations/PostRemoteOps.cs
+++ b/ConDep.Dsl/Operations/PostRemoteOps.cs
@@ -24,7 +24,7 @@ if($service) {{
 
 Remove-Item -force -recurse {0}{1}",
                     @"$env:windir\temp\ConDep\", ConDepGlobals.ExecId);
-            var executor = new PowerShellExecutor(server);
+            var executor = new PowerShellExecutor(server) {LoadConDepModule = false};
             executor.Execute(script);
         }
 


### PR DESCRIPTION
The module ServerManager does not exist in Windows Server 2008.
The needed Api:s was added first in Win 2008 R2.

By removing this dependency we can use ConDep to deploy applications
to Win Srv 2008. But not infrastructure.
