### PR TITLE
Default timeout for HttpClient is 100s. It may not be enough sometimes.

### DIFF
--- a/ConDep.Dsl/Remote/Node/Api.cs
+++ b/ConDep.Dsl/Remote/Node/Api.cs
@@ -21,6 +21,7 @@ namespace ConDep.Dsl.Remote.Node
             var messageHandler = new HttpClientHandler { Credentials = new NetworkCredential(userName, password) };
             _client = new HttpClient(messageHandler) { BaseAddress = new Uri(url) };
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _client.Timeout = TimeSpan.FromMinutes(5); // Default is 100s
         }
 
         public SyncResult SyncDir(string srcPath, string dstPath)


### PR DESCRIPTION
I had problems on Amazon where my buildserver is a small-instance. This is a quickfix that works fine.
