### PR TITLE
Added possibility to skip loading ConDep module when executing Powershell.

### DIFF
--- a/ConDep.Dsl/IOfferPowerShellOptions.cs
+++ b/ConDep.Dsl/IOfferPowerShellOptions.cs
@@ -9,6 +9,12 @@ namespace ConDep.Dsl
         IOfferPowerShellOptions RequireRemoteLib();
 
         /// <summary>
+        /// Skip loading of the ConDep powershell modules. 
+        /// </summary>
+        /// <returns></returns>
+        IOfferPowerShellOptions SkipLoadingConDepModule();
+
+        /// <summary>
         /// If true, will continue execution even if an error occur during operation execution
         /// </summary>
         /// <param name="value"></param>

--- a/ConDep.Dsl/Operations/Application/Execution/PowerShell/PowerShellOptions.cs
+++ b/ConDep.Dsl/Operations/Application/Execution/PowerShell/PowerShellOptions.cs
@@ -10,6 +10,12 @@
             return this;
         }
 
+        public IOfferPowerShellOptions SkipLoadingConDepModule()
+        {
+            _values.SkipLoadingConDepModule = true;
+            return this;
+        }
+
         public IOfferPowerShellOptions ContinueOnError(bool value)
         {
             _values.ContinueOnError = value;
@@ -21,6 +27,8 @@
         public class PowerShellOptionValues
         {
             public bool RequireRemoteLib { get; set; }
+
+            public bool SkipLoadingConDepModule { get; set; }
 
             public bool ContinueOnError { get; set; }
         }

--- a/ConDep.Dsl/Operations/Application/Execution/PowerShell/RemotePowerShellHostOperation.cs
+++ b/ConDep.Dsl/Operations/Application/Execution/PowerShell/RemotePowerShellHostOperation.cs
@@ -26,10 +26,19 @@ namespace ConDep.Dsl.Operations.Application.Execution.PowerShell
         public override void Execute(ServerConfig server, IReportStatus status, ConDepSettings settings)
         {
             var psExec = new PowerShellExecutor(server);
-            if (_values != null && _values.RequireRemoteLib)
+            if (_values != null)
             {
-                psExec.LoadConDepDotNetLibrary = true;
+                if (_values.RequireRemoteLib)
+                {
+                    psExec.LoadConDepDotNetLibrary = true;
+                }
+
+                if (_values.SkipLoadingConDepModule)
+                {
+                    psExec.LoadConDepModule = false;
+                }
             }
+
             psExec.Execute(_cmd);
         }
 


### PR DESCRIPTION
This is for supporting Remote Execution on Windows Server 2008 where
ServerManager-module does not exist.
