### PR TITLE
Fixed bug where an exception is thrown if the paths differ on capitalization

### DIFF
--- a/ConDep.Dsl/Remote/Node/Api.cs
+++ b/ConDep.Dsl/Remote/Node/Api.cs
@@ -54,7 +54,7 @@ namespace ConDep.Dsl.Remote.Node
             if (syncResponse.IsSuccessStatusCode)
             {
                 var webAppInfo = syncResponse.Content.ReadAsAsync<WebAppInfo>().Result;
-                if (!string.IsNullOrWhiteSpace(dstPath) && webAppInfo.Exist && webAppInfo.PhysicalPath != dstPath)
+                if (!string.IsNullOrWhiteSpace(dstPath) && webAppInfo.Exist && NormalizePath(webAppInfo.PhysicalPath) != NormalizePath(dstPath))
                 {
                     throw new ArgumentException(string.Format("Web app {0} already exist and physical path differs from path provided.", webAppName));
                 }
@@ -239,6 +239,13 @@ namespace ConDep.Dsl.Remote.Node
             {
                 return false;
             }
+        }
+
+        public static string NormalizePath(string path)
+        {
+            return Path.GetFullPath(new Uri(path).LocalPath)
+                       .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                       .ToUpperInvariant();
         }
     }
 }


### PR DESCRIPTION
For example the path c:\inetpub was different from C:\inetpub.
