### PR TITLE
Hardening of ConDepNode file-handling, and added logging to client.

### DIFF
--- a/ConDep.Dsl/Remote/Node/Api.cs
+++ b/ConDep.Dsl/Remote/Node/Api.cs
@@ -204,7 +204,22 @@ namespace ConDep.Dsl.Remote.Node
                         var syncResult = task.Result.Content.ReadAsAsync<SyncResult>().Result;
                         return syncResult;
                     }
-                    return null;
+                    else
+                    {
+                        var errorResult = task.Result.Content.ReadAsAsync<SyncResult>().Result;
+
+                        foreach (var entry in errorResult.Log)
+                        {
+                            Logger.Info(entry);    
+                        }
+
+                        foreach (var error in errorResult.Errors)
+                        {
+                            Logger.Error(error);    
+                        }
+
+                        throw new ApplicationException("Error while deploying WebApp. See log for more information");
+                    }
                 });
             result.Wait();
             return result.Result;

--- a/ConDep.Dsl/Remote/Node/Model/SyncResult.cs
+++ b/ConDep.Dsl/Remote/Node/Model/SyncResult.cs
@@ -9,11 +9,13 @@ namespace ConDep.Dsl.Remote.Node.Model
         private readonly List<string> _updatedFiles = new List<string>();
         private readonly List<string> _createdFiles = new List<string>();
         private readonly List<string> _log = new List<string>();
+        private readonly List<string> _errors = new List<string>();
 
         public List<string> DeletedFiles { get { return _deletedFiles; } }
         public List<string> DeletedDirectories { get { return _deletedDirectories; } }
         public List<string> UpdatedFiles { get { return _updatedFiles; } }
         public List<string> CreatedFiles { get { return _createdFiles; } }
         public List<string> Log { get { return _log; } }
+        public List<string> Errors { get { return _errors; } }
     }
 }

--- a/ConDep.Node/Model/SyncResult.cs
+++ b/ConDep.Node/Model/SyncResult.cs
@@ -9,11 +9,13 @@ namespace ConDep.Node.Model
         private readonly List<string> _updatedFiles = new List<string>();
         private readonly List<string> _createdFiles = new List<string>();
         private readonly List<string> _log = new List<string>();
+        private readonly List<string> _errors = new List<string>();
 
         public List<string> DeletedFiles { get { return _deletedFiles; } }
         public List<string> DeletedDirectories { get { return _deletedDirectories; } }
         public List<string> UpdatedFiles { get { return _updatedFiles; } }
         public List<string> CreatedFiles { get { return _createdFiles; } }
         public List<string> Log { get { return _log; } }
+        public List<string> Errors { get { return _errors; } }
     }
 }

--- a/ConDep.Node/MultipartSyncDirStreamProvider.cs
+++ b/ConDep.Node/MultipartSyncDirStreamProvider.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.AccessControl;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using ConDep.Node.Model;
@@ -57,51 +59,80 @@ namespace ConDep.Node
             FileData.Add(fileData);
 
             var file = new FileInfo(localFilePath);
-            if(file.Exists)
+            if (file.Exists)
             {
                 SyncResult.UpdatedFiles.Add(localFilePath);
                 SyncResult.Log.Add("Updated: " + localFilePath);
             }
             else
             {
-                Directory.CreateDirectory(file.DirectoryName);
-                SyncResult.CreatedFiles.Add(localFilePath);
-                SyncResult.Log.Add("Created: " + localFilePath);
+                try
+                {
+                    Directory.CreateDirectory(file.DirectoryName);
+                    SyncResult.CreatedFiles.Add(localFilePath);
+                    SyncResult.Log.Add("Created: " + localFilePath);
+                }
+                catch (Exception ex)
+                {
+                    SyncResult.Errors.Add(string.Format("Error: Could not create directory {0}. Error: {1}", 
+                        file.DirectoryName,
+                        ex.Message));
+                }
             }
 
-            return File.Create(localFilePath, BufferSize, FileOptions.Asynchronous);
+            Stream fileStream;
+            try
+            {
+                fileStream = File.Create(localFilePath, BufferSize, FileOptions.Asynchronous);
+            }
+            catch (Exception ex)
+            {
+                SyncResult.Errors.Add(string.Format("Error: Could not create file {0}. Error: {1}", localFilePath,
+                    ex.Message));
+                fileStream = new MemoryStream();
+            }
+
+            return fileStream;
+
         }
 
         public override Task ExecutePostProcessingAsync()
         {
-            foreach (var fileData in FileData)
+            try
             {
-                var contentDisposition = fileData.Headers.ContentDisposition;
-
-                var filePath = Path.Combine(RootPath, contentDisposition.FileName.Trim('"'));
-                
-                var fileTimeString = contentDisposition.Parameters.FirstOrDefault(x => x.Name == "lastWriteTimeUtc");
-                var fileTimeLong = Convert.ToInt64(fileTimeString.Value);
-                var lastWriteTimeUtc = DateTime.FromFileTime(fileTimeLong);
-                
-                var attributes = contentDisposition.Parameters.FirstOrDefault(x => x.Name == "fileAttributes");
-
-                FileAttributes fileAttributes;
-                FileAttributes.TryParse(HttpUtility.UrlDecode(attributes.Value), true, out fileAttributes);
-
-                UpdateFileWithOriginalSettings(filePath, lastWriteTimeUtc, fileAttributes);
-            }
-
-            if(_postProcContentMarker > -1)
-            {
-                var deleteJson = Contents[_postProcContentMarker];
-                var data = deleteJson.ReadAsAsync<SyncPostProcContent>().Result;
-
-                if(data != null)
+                foreach (var fileData in FileData)
                 {
-                    DeleteFiles(data);
-                    ChangeAttributesOnFolders(data);
+                    var contentDisposition = fileData.Headers.ContentDisposition;
+
+                    var filePath = Path.Combine(RootPath, contentDisposition.FileName.Trim('"'));
+
+                    var fileTimeString = contentDisposition.Parameters.FirstOrDefault(x => x.Name == "lastWriteTimeUtc");
+                    var fileTimeLong = Convert.ToInt64(fileTimeString.Value);
+                    var lastWriteTimeUtc = DateTime.FromFileTime(fileTimeLong);
+
+                    var attributes = contentDisposition.Parameters.FirstOrDefault(x => x.Name == "fileAttributes");
+
+                    FileAttributes fileAttributes;
+                    FileAttributes.TryParse(HttpUtility.UrlDecode(attributes.Value), true, out fileAttributes);
+
+                    UpdateFileWithOriginalSettings(filePath, lastWriteTimeUtc, fileAttributes);
                 }
+
+                if (_postProcContentMarker > -1)
+                {
+                    var deleteJson = Contents[_postProcContentMarker];
+                    var data = deleteJson.ReadAsAsync<SyncPostProcContent>().Result;
+
+                    if (data != null)
+                    {
+                        DeleteFiles(data);
+                        ChangeAttributesOnFolders(data);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                SyncResult.Errors.Add(string.Format("Error: Could not complete post processing of files. {0}", e));
             }
 
             return base.ExecutePostProcessingAsync();
@@ -126,27 +157,69 @@ namespace ConDep.Node
 
         private void DeleteFiles(SyncPostProcContent content)
         {
-            foreach(var file in content.DeletedFiles)
+            DeleteTheFiles(content);
+            DeleteTheDirectories(content);
+        }
+
+        private void DeleteTheFiles(SyncPostProcContent content)
+        {
+            foreach (var file in content.DeletedFiles)
             {
                 var fileInfo = new FileInfo(file.Path) {Attributes = FileAttributes.Normal};
-                fileInfo.Delete();
-                SyncResult.DeletedFiles.Add(file.Path);
-                SyncResult.Log.Add("Deleted: " + file.Path);
+                try
+                {
+                    fileInfo.Delete();
+                    SyncResult.DeletedFiles.Add(file.Path);
+                    SyncResult.Log.Add("Deleted: " + file.Path);
+                }
+                catch (Exception e)
+                {
+                    var msg = string.Format("Error: Could not delete the file '{0}'. Error: {1}", file.Path, e.Message);
+                    SyncResult.Errors.Add(msg);
+                }
             }
+        }
 
+        private void DeleteTheDirectories(SyncPostProcContent content)
+        {
             foreach (var dir in content.DeletedDirectories.OrderByDescending(x => x.RelativePath))
             {
-                var dirInfo = new DirectoryInfo(dir.Path) { Attributes = FileAttributes.Normal };
-                dirInfo.Delete();
-                SyncResult.DeletedDirectories.Add(dir.Path);
-                SyncResult.Log.Add("Deleted: " + dir.Path);
+                var dirInfo = new DirectoryInfo(dir.Path) {Attributes = FileAttributes.Normal};
+                try
+                {
+                    dirInfo.Delete();
+                    SyncResult.DeletedDirectories.Add(dir.Path);
+                    SyncResult.Log.Add("Deleted: " + dir.Path);
+                }
+                catch (Exception e)
+                {
+                    var msg = string.Format("Error: Could not delete the directory '{0}'. Error: {1}", dir.Path,
+                        e.Message);
+                    SyncResult.Errors.Add(msg);
+                }
             }
         }
 
         private void UpdateFileWithOriginalSettings(string filePath, DateTime lastWriteTimeUtc, FileAttributes fileAttributes)
         {
-            File.SetLastWriteTime(filePath, lastWriteTimeUtc);
-            File.SetAttributes(filePath, fileAttributes);
+            // A known bug in in the framework sometimes locks the file after it is saved to disk.
+            // See http://aspnetwebstack.codeplex.com/workitem/282
+            // The bug is fixed in framework 4.5 but we target also framework 4 so we need this loop-workaround.
+            for (int i = 0; i < 10; i++)
+            {
+                try
+                {
+                    File.SetLastWriteTime(filePath, lastWriteTimeUtc);
+                    File.SetAttributes(filePath, fileAttributes);
+                    return;
+                }
+                catch (Exception)
+                {
+                    Thread.Sleep(50);
+                }
+            }
+
+            SyncResult.Log.Add(string.Format("Warning: Could not set original settings (LastWriteTime and Attributes) on file: {0}", filePath));
         }
 
         public override string GetLocalFileName(HttpContentHeaders headers)


### PR DESCRIPTION
- Added detection and logging of errors when overwriting files on server.
  If a file is readonly on server when deploying the file-copy stops silently
  and the user gets no notification.
- Exception thrown in ExecutePostProcessingAsync in MultipartSyncDirStreamProvider
  deadlocks the controller and ConDep times out without the user getting any info.
  A nasty bug in the framework makes this happen about 1% of the time when setting
  attributes and LastWriteTime.
  (see http://aspnetwebstack.codeplex.com/workitem/282)
- Logs errors on client side for so user can do something about the error.
